### PR TITLE
Update README to use the heroku buildpack URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Adapted from [SectorLabs/heroku-buildpack-git-submodule](https://github.com/Sect
 1. Add the buildpack to your Heroku app:
 
     ```
-    $ heroku buildpacks:add https://github.com/RasPhilCo/heroku-buildpack-ssh-key.git -i 1
+    $ heroku buildpacks:add https://github.com/heroku/heroku-buildpack-ssh-key.git -i 1
     ```
 
     Keep in mind that the buildpack order is important. If you'll specify this buildpack after your default one (e.g. `heroku/nodejs`) it'll not work. See [https://devcenter.heroku.com/articles/using-multiple-buildpacks-for-an-app](https://devcenter.heroku.com/articles/using-multiple-buildpacks-for-an-app) for details.
@@ -18,7 +18,7 @@ Adapted from [SectorLabs/heroku-buildpack-git-submodule](https://github.com/Sect
 2. Set `BUILDPACK_SSH_KEY` to the private SSH key you want added:
 
     ```
-    $ heroku config:set BUILDPACK_SSH_KEY=$(cat ~/.ssh/id_rsa)
+    $ heroku config:set BUILDPACK_SSH_KEY="$(cat ~/.ssh/id_rsa)"
     ```
 
 The buildpack will save the SSH key to your build at `~/.ssh/id_rsa`.


### PR DESCRIPTION
Also quote the private key config var value, because I got an error without them.