### PR TITLE
Quotes are required around cat

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Adapted from [SectorLabs/heroku-buildpack-git-submodule](https://github.com/Sect
 2. Set `BUILDPACK_SSH_KEY` to the private SSH key you want added:
 
     ```
-    $ heroku config:set BUILDPACK_SSH_KEY=$(cat ~/.ssh/id_rsa)
+    $ heroku config:set BUILDPACK_SSH_KEY="$(cat ~/.ssh/id_rsa)"
     ```
 
 The buildpack will save the SSH key to your build at `~/.ssh/id_rsa`.


### PR DESCRIPTION
Quotes are required around `"$(cat ~/.ssh/id_rsa)"`, otherwise 
the command 
```
heroku config:set BUILDPACK_SSH_KEY=$(cat ~/.ssh/id_rsa)"`
```
fails with 

```
RSA is invalid. Must be in the format FOO=bar
```